### PR TITLE
Improve onboarding consistency

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -1,7 +1,9 @@
-<img src="images/IntermountainMeshLogo.svg" width="45%" hspace="40">
+<img src="images/IntermountainMeshLogo.svg" width="30%" hspace="40">
 
 # Freq51 - The Intermountain Mesh
-Meshtastic® lets you use inexpensive LoRa radios as a long-range, off-grid communication platform where regular infrastructure is unreliable or unavailable. It’s community-driven and open source. Radios automatically form a mesh, forwarding packets to neighbors (up to 7 hops from origin). Phones are optional. **The Freq51 community** is building an open community mesh that anyone here can join. This network is intended as a Radio Frequency tool for emergency/disaster response and off-grid (non-internet) coordination and hobbyist projects. No license is required to use Meshtastic (unless you intentionally enable Ham Mode). Meshtastic is under active development and **not** a life-critical service. 
+Meshtastic® is a network protocol that lets you use [inexpensive radios](https://meshtastic.org/docs/hardware/devices/) for long-range, off-grid communication where regular infrastructure is unreliable or unavailable. Radios (nodes) automatically share messages when using the [same settings](config.md), forwarding packets to neighbors up to 7 hops from where a message started. Phones are optional. Users can send text messages in channels or DMs, and share position or weather data if using a device with connected sensors.
+
+The [Freq51 community](https://utahmesh.net) is building one such mesh network that spans Utah and Idaho that anyone can join. The network is intended for non-life-critical emergency/disaster communication, off-grid coordination, and hobbyist projects. You don't need a license to use Meshtastic (unless you intentionally enable Ham mode), just a compatible radio.
 
 
 | ![Idaho](images/map-idaho.png) | ![Utah](images/map-utah.png) |

--- a/src/README.md
+++ b/src/README.md
@@ -9,15 +9,15 @@ Meshtastic® lets you use inexpensive LoRa radios as a long-range, off-grid comm
 | **Idaho**                       | **Utah**                     |
 ---
 
-## Joining
+## How to get started
 
-1. **Get supported hardware** from the Meshtastic list.
-2. **Join our [Discord](https://utahmesh.net)** for local help and announcements.
-3. Read the **[FAQ](faq.md)** and **[Configuration](config.md)** pages below.
-4. See **[Equipment](equipment.md)** for example builds / coverage once published, and **[Infrastructure](infrastructure.md)** for deployed nodes.
+1. **Buy or build a node** You can use any [Meshtastic supported device](https://meshtastic.org/docs/hardware/devices/) but if you are new, buying one that already has battery, antennas, GPS (if desired), and case is a solid option. Some sellers may need you to select a frequency option, in which case select 915Mhz (US region). You can fully use and configure your device from a computer or cell phone, so features like screen, keyboard, or buttons are entirely optional.
+2. **Configure your device** Our [onboarding guide](onboarding.md) will help you update your firmware, load settings to connect to the Freq51 network, and help you choose your node role.
+3. **Join our [Discord](https://utahmesh.net)** for local help and announcements.
+4. If you are curious about how the network works, read our **[FAQ](faq.md)**, **[Configuration](config.md)**, and **[Infrastructure](infrastructure.md)** for more info
+
 
 **Links**
-- Supported Hardware: [https://meshtastic.org/docs/hardware/devices/](https://meshtastic.org/docs/hardware/devices/)
 -  **[Official Meshtastic Discord](https://discord.gg/meshtastic) --> [Connect Forum](https://discord.com/channels/867578229534359593/1196916552725958706) --> US-Utah**
 
 ---

--- a/src/channels.md
+++ b/src/channels.md
@@ -1,5 +1,7 @@
 # Meshtastic Channel Setup Guide
 
+⚠️ If you are setting up a device, we recommend using the [onboarding guide](onboarding.md) which includes the Freq51 Auto Config Tool. This tool can auto apply all of these settings for you 👍
+
 A guide to setting up **private and other channels** on your Meshtastic node.  
 Each channel includes its name, key, and purpose.  
 Use this to configure your node to connect with local or community networks.

--- a/src/channels.md
+++ b/src/channels.md
@@ -6,6 +6,8 @@ A guide to setting up **private and other channels** on your Meshtastic node.
 Each channel includes its name, key, and purpose.  
 Use this to configure your node to connect with local or community networks.
 
+> We will not be providing nor publish QR codes or Meshtastic URLs for public channels. They can also change LoRa settings (hop count, OK to MQTT, TX power) invisibly. Enter channel names/keys manually. If you would like to create a channel for a specific purpose but wish it to be public use; contact us and we will add it to the documentation as requested.
+
 ---
 
 ## 🧭 Table of Contents

--- a/src/channels.md
+++ b/src/channels.md
@@ -66,9 +66,7 @@ They should only be used for legitimate emergency traffic, drills, or official c
 
 ⚠️ Keep messages clear, concise, and relevant. Avoid general chat on these channels.
 
-| Channel Name | Role | PSK/Key | Description |
-|---------------|------|----------|--------------|
-| `` | Secondary | `empty` | `` |
+👉 [Emergency Comms Channels](emergency-comms.md)
 
 💬 *These emergency channels provide structured communication during incidents while keeping the primary mesh available for general traffic.*
 

--- a/src/config.md
+++ b/src/config.md
@@ -79,7 +79,7 @@ If you can’t find a setting in the app, check Meshtastic docs (each page has i
 
 ### Router Nodes
 
-Before configuring a router, review the [Router Deployment Guide](advanced-configuration/router-deployment.md) and reach out on Discord.
+Before configuring a router, review the [Router Deployment Guide](advanced-configuration/router-deployment.md) and reach out on [Discord](https://utahmesh.net).
 
 Use when node is a router
 

--- a/src/config.md
+++ b/src/config.md
@@ -1,4 +1,4 @@
-# Meshtastic Configuration
+# Freq51 Meshtastic Configuration
 
 ⚠️ If you are setting up a device, we recommend using the [onboarding guide](onboarding.md) which includes the Freq51 Auto Config Tool. This tool can auto apply all of these settings for you 👍
 
@@ -11,7 +11,14 @@ These sections help you choose settings that work well **for you** and **for the
 
 ---
 
-## Default Configurations (We are not using this)
+## Channels
+
+To send & receive messages on the Freq51 network, you will need to configure matching channels.
+👉 [See our channel list here](channels.md)
+
+---
+
+## We are not using the Default Configuration
 
 By default, fresh Meshtastic radios on NA region can talk on **LongFast** (channel name) using the **LONG_FAST** preset and **default slot**. A typical setup is a radio paired to your phone via Bluetooth. No internet is required. When out of direct range, your messages **hop** across other nodes.
 
@@ -229,30 +236,3 @@ To appear on the map:
 - **Map Reporting Enabled**: `TRUE`
 - **Map Report Publish Interval**: Fixed `Same as standard config broadcast interval` s; Portable `no more frequent than 600` s
 - **Approximate Location**: set as desired
-
----
-
-## Local Channels
-
-> We will not be providing nor publish QR codes or Meshtastic URLs for public channels. They can also change LoRa settings (hop count, OK to MQTT, TX power) invisibly. Enter channel names/keys manually. If you would like to create a channel for a specific purpose but wish it to be public use; contact us and we will add it to the documentation as requested.
-
-### MediumFast
-
-Default community channel on Medium_Fast. We use this channel to connect the mesh together on a unified unencrypted channel and also broadcast. This resides in our secondary channels
-
-| Channel Name | PSK  | Modem Preset | Slot | Ham Mode |
-|---|---|---|---|---|
-| Freq51 | `1A==` | Medium_Fast | 51 | Off |
-
-
-### DC801
-
-This is the local hackerspace channel. The key is only found at the hackerspace. Come join us!
-
-| Channel Name | PSK  | Modem Preset | Slot | Ham Mode |
-|---|---|---|---|---|
-| ShortFast | `access hackerspace for key` | LONG_FAST | 51 | Off |
-
-
-
-

--- a/src/config.md
+++ b/src/config.md
@@ -1,6 +1,8 @@
 # Meshtastic Configuration
 
-These sections help you choose settings that work well **for you** and **for the mesh**. See the FAQ for troubleshooting. Locally we’re still building out on the FS51 with the default MediumFast North America slot/preset (see below), but freq51 may coordinate short-term trials (e.g., ShortFast) as needed.
+⚠️ If you are setting up a device, we recommend using the [onboarding guide](onboarding.md) which includes the Freq51 Auto Config Tool. This tool can auto apply all of these settings for you 👍
+
+These sections help you choose settings that work well **for you** and **for the mesh**. See the **[FAQ](faq.md)** for troubleshooting. Locally we’re still building out on the FS51 with the default MediumFast North America slot/preset (see below), but freq51 may coordinate short-term trials (e.g., ShortFast) as needed.
 
 **Freq51 Medium Fast** (As of 10/05/2025):
 - **Medium_Fast** preset, **slot 51** → **914.625 MHz**


### PR DESCRIPTION
### Purpose:

Preset, frequency, and channel settings are defined in multiple places right now. As a new user, this meant my onboarding took a few tries.

### Proposed changes:

- Removes duplicate channels section on the config page, but cross links to the channels page
- Links from the emergency comms section of the channels page to the emergency comms page
- Adds a reference to the top of config and channels pages to the onboarding guide
- Updates the front-page "joining" section to reference the onboarding guide
- Updates the front-page text to address questions I have faced when explaining Freq51 to new or less-technical friends